### PR TITLE
Fix : fixed the event handling for menu close 

### DIFF
--- a/app.js
+++ b/app.js
@@ -67,7 +67,7 @@ listItems.forEach((element) => {
 
 // Event listener for window click to hide navbar
 window.addEventListener('click', function (e) {
-    if (!navBar.contains(e.target) && e.target !== menuBar && !menuBar.contains(e.target)) {
+    if (!navBar.contains(e.target) && e.target !== menuBar && !menuBar.contains(e.target) && this.window.innerWidth <= 767) {
         navBar.style.display = 'none';
     }
 });

--- a/static/media-queries.css
+++ b/static/media-queries.css
@@ -1,4 +1,4 @@
-@media (max-width:768px ) {
+@media (max-width:767px ) {
 
     .navbar-on-the-righthandside-profile{
         overflow: hidden;


### PR DESCRIPTION
Previously when users click on anywhere on the portfolio, the menu disappear as i wasn't limiting it to only tablets and mobile, now its fixed, added an innerwidth to only affect mobile and tablets